### PR TITLE
Clarify new ESM syntax in usage example

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,10 @@ to authenticate Steam users from your game backend without needing to verify wit
 - `encryptionKey` - A `Buffer` or hex string containing the app's decryption key
 
 ```js
+// CJS Syntax
 const AppTicket = require('steam-appticket');
+// ESM Syntax
+import * as AppTicket from 'steam-appticket';
 
 const ticket = Buffer.from('<ticket hex>', 'hex');
 const decryptionKey = '6ef99262a7da9e9979737d0822d5d66d03eb0c580b305981a505648b3e21b12e';


### PR DESCRIPTION
With version 2.0.0, the way you should import the package in ESM has changed. If you use the old syntax, it will be unable to find the functions the package exports. This documentation change clarifies the difference to avoid confusion.